### PR TITLE
Feature/add admin only function 202603

### DIFF
--- a/packages/cdk/cdk.json
+++ b/packages/cdk/cdk.json
@@ -34,7 +34,7 @@
     "embeddingModelId": "amazon.titan-embed-text-v2:0",
     "rerankingModelId": null,
     "queryDecompositionEnabled": false,
-    "selfSignUpEnabled": true,
+    "selfSignUpEnabled": false,
     "allowedSignUpEmailDomains": null,
     "samlAuthEnabled": false,
     "samlCognitoDomainName": "",

--- a/packages/cdk/lambda/adminOnly.ts
+++ b/packages/cdk/lambda/adminOnly.ts
@@ -1,0 +1,49 @@
+import { TestInvokeByAdminEvent } from 'generative-ai-use-cases';
+
+export const handler = async (event: TestInvokeByAdminEvent) => {
+  try {
+    console.log('Getting token usage statistics', { event });
+
+    // Get groups and user from Cognito
+    const adminEmail = event.requestContext.authorizer!.claims.email;
+    const adminUserName =
+      event.requestContext.authorizer!.claims['cognito:username'];
+    const groups = event.requestContext.authorizer!.claims['cognito:groups'];
+
+    if (!groups || !groups.includes('admin')) {
+      return {
+        statusCode: 403,
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+        },
+        body: JSON.stringify({
+          message: 'Forbidden',
+        }),
+      };
+    }
+
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: JSON.stringify({
+        message: `invoked by admin user ${adminEmail}(${adminUserName}) with groups ${groups}`,
+      }),
+    };
+  } catch (error) {
+    return {
+      statusCode: 500,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: JSON.stringify({
+        message: 'Internal server error',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }),
+    };
+  }
+};

--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -833,6 +833,15 @@ export class Api extends Construct {
     table.grantReadData(getTokenUsageFunction);
     props.statsTable.grantReadData(getTokenUsageFunction);
 
+    // Lambda function for admin-only actions
+    const adminOnlyFunction = new NodejsFunction(this, 'AdminOnlyFunction', {
+      runtime: LAMBDA_RUNTIME_NODEJS,
+      entry: './lambda/adminOnly.ts',
+      timeout: Duration.minutes(1),
+      vpc,
+      securityGroups,
+    });
+
     // API Gateway
     const authorizer = new CognitoUserPoolsAuthorizer(this, 'Authorizer', {
       cognitoUserPools: [userPool],
@@ -1138,6 +1147,15 @@ export class Api extends Construct {
     tokenUsageResource.addMethod(
       'GET',
       new LambdaIntegration(getTokenUsageFunction),
+      commonAuthorizerProps
+    );
+
+    // GET: /admin-only/test-invoke
+    const adminResource = api.root.addResource('admin-only');
+    const adminOnlyTestInvokeResorce = adminResource.addResource('test-invoke');
+    adminOnlyTestInvokeResorce.addMethod(
+      'GET',
+      new LambdaIntegration(adminOnlyFunction),
       commonAuthorizerProps
     );
 

--- a/packages/types/src/admin-only.d.ts
+++ b/packages/types/src/admin-only.d.ts
@@ -1,0 +1,16 @@
+export interface TestInvokeByAdminResponse {
+  message: string;
+}
+
+export interface TestInvokeByAdminEvent {
+  requestContext: {
+    authorizer: {
+      claims: {
+        email: string;
+        'cognito:username': string;
+        'cognito:groups': string;
+        [key: string]: string | undefined;
+      };
+    };
+  };
+}

--- a/packages/types/src/index.d.ts
+++ b/packages/types/src/index.d.ts
@@ -21,3 +21,4 @@ export * from './mcp';
 export * from './agent-core';
 export * from './agent-builder';
 export * from './mcp-servers';
+export * from './admin-only';

--- a/packages/web/src/components/DrawerBase.tsx
+++ b/packages/web/src/components/DrawerBase.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import useSWR from 'swr';
 import useVersion from '../hooks/useVersion';
 import IconWithDot from './IconWithDot';
-import { PiChartBar, PiGear } from 'react-icons/pi';
+import { PiChartBar, PiGear, PiSquaresFour } from 'react-icons/pi';
 import { fetchAuthSession } from 'aws-amplify/auth';
 import useUserSetting from '../hooks/useUserSetting';
 import { useTranslation } from 'react-i18next';
@@ -27,6 +27,9 @@ const DrawerBase: React.FC<Props> = (props) => {
   const email = useMemo<string>(() => {
     return (data?.tokens?.idToken?.payload.email ?? '') as string;
   }, [data]);
+  const groups = useMemo<string[]>(() => {
+    return (data?.tokens?.idToken?.payload['cognito:groups'] ?? []) as string[];
+  }, [data]);
 
   const hasUpdate = getHasUpdate();
 
@@ -45,6 +48,11 @@ const DrawerBase: React.FC<Props> = (props) => {
               <div className="truncate text-xs">{email}</div>
             )}
             <div className="grow" />
+            {groups.includes('admin') && (
+              <Link to="/admin-only" title="AdminOnly">
+                <PiSquaresFour className="text-lg" />
+              </Link>
+            )}
             <Link to="/stats" title={t('stat.title')}>
               <PiChartBar className="text-lg" />
             </Link>

--- a/packages/web/src/hooks/useAdminOnlyApi.ts
+++ b/packages/web/src/hooks/useAdminOnlyApi.ts
@@ -1,0 +1,24 @@
+import { TestInvokeByAdminResponse } from 'generative-ai-use-cases';
+import useHttp from './useHttp';
+
+const useAdminOnlyApi = () => {
+  const { api } = useHttp();
+
+  const getFeedbacksForAdmin = async (): Promise<TestInvokeByAdminResponse> => {
+    try {
+      const response = await api.get<TestInvokeByAdminResponse>(
+        `admin-only/test-invoke`
+      );
+      return response.data;
+    } catch (error) {
+      console.error('API Error:', error);
+      throw error;
+    }
+  };
+
+  return {
+    getFeedbacksForAdmin,
+  };
+};
+
+export default useAdminOnlyApi;

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -12,6 +12,7 @@ import {
 import LandingPage from './pages/LandingPage';
 import Setting from './pages/Setting';
 import StatPage from './pages/StatPage.tsx';
+import AdminOnlyPage from './pages/AdminPage.tsx';
 import ChatPage from './pages/ChatPage';
 import SharedChatPage from './pages/SharedChatPage';
 import SummarizePage from './pages/SummarizePage';
@@ -87,6 +88,10 @@ const routes: RouteObject[] = [
   {
     path: '/stats',
     element: <StatPage />,
+  },
+  {
+    path: '/admin-only',
+    element: <AdminOnlyPage />,
   },
   {
     path: '/chat',

--- a/packages/web/src/pages/AdminPage.tsx
+++ b/packages/web/src/pages/AdminPage.tsx
@@ -1,0 +1,29 @@
+import React, { useState } from 'react';
+import useAdminOnlyApi from '../hooks/useAdminOnlyApi';
+
+const AdminPage: React.FC = () => {
+  const { getFeedbacksForAdmin } = useAdminOnlyApi();
+  const [message, setMessage] = useState<string>('');
+
+  return (
+    <div className="px-4 py-6 lg:px-8">
+      {/* eslint-disable-next-line @shopify/jsx-no-hardcoded-content */}
+      <div className="mb-6 text-center text-xl font-semibold">AdminOnly</div>
+      <div className="flex justify-center">
+        {/* eslint-disable-next-line @shopify/jsx-no-hardcoded-content */}
+        <button
+          className="bg-aws-smile rounded px-4 py-2 font-semibold text-white hover:opacity-90"
+          onClick={async () => {
+            const response = await getFeedbacksForAdmin();
+            console.log('Response:', response);
+            setMessage(response.message);
+          }}>
+          Test Invoke
+        </button>
+      </div>
+      <div className="ml-4 p-4 text-center text-lg font-medium">{message}</div>
+    </div>
+  );
+};
+
+export default AdminPage;


### PR DESCRIPTION
This pull request introduces a new "AdminOnly" feature that adds an admin-restricted API endpoint and a corresponding UI page, accessible only to users in the "admin" Cognito group. The changes include backend Lambda/API Gateway integration, frontend route and UI updates, and a new React hook for API calls. Additionally, self sign-up is now disabled in the CDK configuration.

**Admin-only API and backend integration:**

* Added a new Lambda function `adminOnlyFunction` in `adminOnly.ts` that checks if the invoking user is an admin and returns a custom message; non-admins receive a 403 Forbidden response. [[1]](diffhunk://#diff-c32eb1b952c782c36dfb2bb57eefb4c5e32bae64474d2b91582ed9e8c5e79059R1-R49) [[2]](diffhunk://#diff-79b9b7fc97c2c702c8c8f38e071f7d451fb26d2825068fed1806c58edf16c671R836-R844)
* Registered a new API Gateway route `GET /admin-only/test-invoke` that invokes the admin-only Lambda and is protected by Cognito authorizer.

**Frontend updates for admin access:**

* Added a new React page `AdminPage.tsx` that allows admin users to test the admin-only API and view the response message. [[1]](diffhunk://#diff-b0106ebcb66387feb002ce8f668e3a11fbc671df5b3a056b70b96e5c0392a566R1-R29) [[2]](diffhunk://#diff-eff38edf5ecc8229d86d752d588d7710c1a55b55ef219ce54dc6d2f7d6bab889R15) [[3]](diffhunk://#diff-eff38edf5ecc8229d86d752d588d7710c1a55b55ef219ce54dc6d2f7d6bab889R92-R95)
* Introduced a new hook `useAdminOnlyApi` to encapsulate the API call logic for the admin-only endpoint.
* Updated the sidebar (`DrawerBase.tsx`) to display an admin-only navigation link (with an icon) for users in the "admin" group, determined from Cognito claims. [[1]](diffhunk://#diff-46586c617fdd0ed1d7a3cd83039d278773a00ba599110b1967890d7d890eb966L7-R7) [[2]](diffhunk://#diff-46586c617fdd0ed1d7a3cd83039d278773a00ba599110b1967890d7d890eb966R30-R32) [[3]](diffhunk://#diff-46586c617fdd0ed1d7a3cd83039d278773a00ba599110b1967890d7d890eb966R51-R55)

**Configuration changes:**

* Disabled self sign-up by setting `selfSignUpEnabled` to `false` in `cdk.json`.## Description of Changes

Please explain the changes in detail.
If there is any impact on existing users (compatibility, degradation, breaking changes, etc.), be sure to include it in the explanation.
